### PR TITLE
Templated file names and contents

### DIFF
--- a/src/actions/dev.ts
+++ b/src/actions/dev.ts
@@ -147,7 +147,22 @@ const dev = (dayRaw: string | undefined) => {
 
   if (!fs.existsSync(toDir)) {
     console.log("Creating from template...")
+    const aocDay = String(dayNum).padStart(2, "0")
+
     copy(fromDir, toDir)
+
+    const files = fs.readdirSync(toDir)
+    for (let i = 0; i < files.length; i += 1) {
+      const newName = files[i].replace(/{{AOC_DAY}}/g, aocDay)
+      if (newName !== files[i]) {
+        fs.renameSync(path.join(toDir, files[i]), path.join(toDir, newName))
+      }
+
+      const contents = fs
+        .readFileSync(path.join(toDir, newName), "utf-8")
+        .replace(/{{AOC_DAY}}/g, aocDay)
+      fs.writeFileSync(path.join(toDir, newName), contents)
+    }
 
     fs.writeFileSync(inputPath, "")
 


### PR DESCRIPTION
This PR updates the logic for creating a new day from templates by replacing `{{AOC_DAY}}` in filenames and in the content of files with the AoC day number (padded to two characters). I put the code directly in the `dev.js` file rather than creating a new file to handle the templating because it's so straightforward, but if you wanted to add more template replacements in the future, a separate file might be easier to reason about.

This is useful for me because I do some of my AoC puzzles in multiple languages, but I like to keep them all together. For consistency, I name them like `day07.js`, `day07.py`, etc. This change to the template allows me to very easily get this sort of file structure:

```
 aoc2017
|__ src
|____ day07
|______ index.js
        day07.js
        day07.py
```

And my `index.js` can correctly import my solution file; e.g.:

```js
import run from "aocrunner";
import { part1, part2 } from "./day07.js";

run({
  part1: { solution: part1 },
  part2: { solution: part2 },
  trimTestInputs: true,
});
```

Previously I have used aocrunner to copy the files, and then manually rename them and update the import, but allowing the template functionality to also handle filenames and contents would be a blessing! 😄 