### PR TITLE
Provide for a graceful exit

### DIFF
--- a/src/actions/dev.ts
+++ b/src/actions/dev.ts
@@ -24,6 +24,7 @@ const showInfo = () => {
   console.log(stripIndent`
     Type ${boldMagenta("fetch")} or ${boldMagenta("f")} - to fetch the input
     Type ${boldMagenta("send")}  or ${boldMagenta("s")} - to send the solutions
+    Type ${boldMagenta("quit")}  or ${boldMagenta("q")} - to quit
   `)
   console.log()
 }
@@ -213,6 +214,9 @@ const dev = (dayRaw: string | undefined) => {
       case "c":
         console.clear()
         break
+      case "quit":
+      case "q":
+        process.exit(0)
       default:
         console.log("Command not supported")
         break


### PR DESCRIPTION
This PR adds a third option to the dev interface to allow a graceful exit instead of requiring the user to use `ctrl+c`. I'm a little mixed on this one because `ctrl+c` is pretty natural for most developers and adding another option here takes up more screen space, but I'm content to open the pull request and let you decide what makes sense. 😄 