### PR TITLE
Make solution processes stoppable

### DIFF
--- a/src/actions/dev.ts
+++ b/src/actions/dev.ts
@@ -114,7 +114,7 @@ const send = async (config: Config, dayNum: number, part: 1 | 2) => {
   return false
 }
 
-const dev = (dayRaw: string | undefined) => {
+const dev = async (dayRaw: string | undefined) => {
   const day = dayRaw && (dayRaw.match(/\d+/) ?? [])[0]
   const config = readConfig()
 
@@ -164,9 +164,9 @@ const dev = (dayRaw: string | undefined) => {
     buildSource(files)
   }
 
-  runSolution(dayNum, indexFile)
+  await runSolution(dayNum, indexFile)
 
-  const reload = (file: string) => {
+  const reload = async (file: string) => {
     if (![".js", ".ts", ".mjs"].includes(path.parse(file).ext)) {
       return
     }
@@ -177,7 +177,7 @@ const dev = (dayRaw: string | undefined) => {
       buildSource(file)
     }
 
-    runSolution(dayNum, indexFile)
+    await runSolution(dayNum, indexFile)
 
     showInfo()
 

--- a/src/actions/processes/runSolution.ts
+++ b/src/actions/processes/runSolution.ts
@@ -16,8 +16,8 @@ const runSolution = async (day: number, path: string) => {
     process.on("SIGINT", stop)
 
     child.on("exit", (code) => {
-      resolve(code)
       process.off("SIGINT", stop)
+      resolve(code)
     })
   })
 }

--- a/src/actions/processes/runSolution.ts
+++ b/src/actions/processes/runSolution.ts
@@ -1,13 +1,25 @@
-import { spawnSync } from "child_process"
+import { spawn } from "child_process"
 import kleur from "kleur"
 
-const runSolution = (day: number, path: string) => {
-  console.log(kleur.blue(`\n-- Day ${day} `.padEnd(40, "-") + "\n"))
-  spawnSync("node", [path], {
-    stdio: "inherit",
-    shell: true,
+const runSolution = async (day: number, path: string) => {
+  return new Promise((resolve) => {
+    console.log(kleur.blue(`\n-- Day ${day} `.padEnd(40, "-") + "\n"))
+    const child = spawn("node", [path], {
+      stdio: "inherit",
+      shell: true,
+    })
+    console.log(kleur.blue("\n".padEnd(40, "-")))
+
+    const stop = () => {
+      child.kill(9)
+    }
+    process.on("SIGINT", stop)
+
+    child.on("exit", (code) => {
+      resolve(code)
+      process.off("SIGINT", stop)
+    })
   })
-  console.log(kleur.blue("\n".padEnd(40, "-")))
 }
 
 export default runSolution


### PR DESCRIPTION
This PR makes it possible to stop a solution that's running too long or stuck in a loop, without killing aocrunner itself. The child process is now made asynchronously. The `runSolution` method is async and returns a promise that resolves when the child process exits. Additionally, `runSolution` attaches a temporary event listener to the main process `SIGINT` event. If it receives a `SIGINT`, it sends a `SIGKILL` to the solution process to end it immediately. Afterwards, the promise resolves and the temporary event listener is removed.