### PR TITLE
feat: add `update:readme`  command

### DIFF
--- a/src/actions/dev.ts
+++ b/src/actions/dev.ts
@@ -9,13 +9,13 @@ import runSolution from "./processes/runSolution.js"
 import copy from "../io/copy.js"
 import { readConfig, saveConfig } from "../io/config.js"
 import { getInput, sendSolution, Status } from "../io/api.js"
-import { saveReadme, readReadme } from "../io/readme.js"
-import { renderDayBadges, renderResults } from "../configs/readmeMD.js"
+
 import readmeDayMD from "../configs/readmeDayMD.js"
 import asciiPrompt, { AsciiOptions } from "../prompts/asciiPrompt.js"
 import commandPrompt from "../prompts/commandPrompt.js"
 
 import type { Config } from "../types/common"
+import updateReadme from "./updateReadMe.js"
 
 const boldMagenta = kleur.bold().magenta
 
@@ -28,23 +28,7 @@ const showInfo = () => {
   console.log()
 }
 
-const updateReadme = () => {
-  const config = readConfig()
-  const badges = renderDayBadges(config)
-  const results = renderResults(config)
 
-  const readme = readReadme()
-    .replace(
-      /<!--SOLUTIONS-->(.|\n)+<!--\/SOLUTIONS-->/,
-      `<!--SOLUTIONS-->\n\n${badges}\n\n<!--/SOLUTIONS-->`,
-    )
-    .replace(
-      /<!--RESULTS-->(.|\n)+<!--\/RESULTS-->/,
-      `<!--RESULTS-->\n\n${results}\n\n<!--/RESULTS-->`,
-    )
-
-  saveReadme(readme)
-}
 
 const send = async (config: Config, dayNum: number, part: 1 | 2) => {
   console.log(`\nPart ${part}:`)

--- a/src/actions/updateReadMe.ts
+++ b/src/actions/updateReadMe.ts
@@ -1,0 +1,23 @@
+import { saveReadme, readReadme } from "../io/readme.js"
+import { renderDayBadges, renderResults } from "../configs/readmeMD.js"
+import { readConfig } from "../io/config.js"
+
+export const updateReadme = () => {
+  const config = readConfig()
+  const badges = renderDayBadges(config)
+  const results = renderResults(config)
+
+  const readme = readReadme()
+    .replace(
+      /<!--SOLUTIONS-->(.|\n)+<!--\/SOLUTIONS-->/,
+      `<!--SOLUTIONS-->\n\n${badges}\n\n<!--/SOLUTIONS-->`,
+    )
+    .replace(
+      /<!--RESULTS-->(.|\n)+<!--\/RESULTS-->/,
+      `<!--RESULTS-->\n\n${results}\n\n<!--/RESULTS-->`,
+    )
+
+  saveReadme(readme)
+}
+
+export default updateReadme

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,12 +2,13 @@
 import init from "./actions/init.js"
 import dev from "./actions/dev.js"
 import build from "./actions/build.js"
+import updateReadme from "./actions/updateReadMe.js"
 import dotenv from "dotenv"
 
 dotenv.config()
 
 const commandPos = process.argv.findIndex((arg) =>
-  ["init", "day", "build"].includes(arg),
+  ["init", "day", "build", "update:readme"].includes(arg),
 )
 
 if (commandPos === -1) {
@@ -29,6 +30,10 @@ switch (String(command || "").toLowerCase()) {
   case "build": {
     build()
     break
+  }
+  case "update:readme": {
+    updateReadme()
+    break;
   }
   default: {
     console.log("Command not supported")

--- a/src/configs/packageJSON.ts
+++ b/src/configs/packageJSON.ts
@@ -12,6 +12,7 @@ const packageJSON = ({ year, language, author }: Setup) => {
       start: "aocrunner day",
       ...build,
       format: "prettier -w src",
+      "update:readme": "aocrunner update:readme",
     },
     keywords: ["aoc"],
     author: author ?? "",


### PR DESCRIPTION
Why this PR? 
I followed the docs and configured the starting template and started solving day 1 of advent of code. 
I misused the template and on my first solution I copied the answer from the console and pasted it directly in AoC website.
 
The answer was correct, but unfortunately, I was no-longer able to send my answers for part 2 using the "send" command as the script will return the following Status and exit.

![image](https://user-images.githubusercontent.com/47872542/205143587-eb08f3cc-8502-453c-b2f5-9d21c6ee43f8.png)

I also read the [note about automated requests](https://github.com/caderek/aocrunner#note-about-automated-requests) and understand the risks/reason behind the implementation.

I do, however miss the feature to automatically update the day badges on the readme file, so here's the proposal.

The `npm run  update:readme` command exposes the existing `updateReadMe()` function thats uses the `.aocrunner.json` to generate the badges.

Let me know of your thoughts :) 

