### PR TITLE
Handle Windows line endings

### DIFF
--- a/src/actions/updateReadMe.ts
+++ b/src/actions/updateReadMe.ts
@@ -9,11 +9,11 @@ export const updateReadme = () => {
 
   const readme = readReadme()
     .replace(
-      /<!--SOLUTIONS-->(.|\n)+<!--\/SOLUTIONS-->/,
+      /<!--SOLUTIONS-->(.|\n|\r)+<!--\/SOLUTIONS-->/,
       `<!--SOLUTIONS-->\n\n${badges}\n\n<!--/SOLUTIONS-->`,
     )
     .replace(
-      /<!--RESULTS-->(.|\n)+<!--\/RESULTS-->/,
+      /<!--RESULTS-->(.|\n|\r)+<!--\/RESULTS-->/,
       `<!--RESULTS-->\n\n${results}\n\n<!--/RESULTS-->`,
     )
 


### PR DESCRIPTION
My `README.md` hadn't been updating as I submitted puzzles, though it was fine on the first day. I actually popped over here to grab the latest and found the new `update:readme` command, but that wasn't working either. I figured out that the regex for swapping the `README.md` content only includes `\n` and not `\r` for us poor saps who have `autoclrf=true` in our git settings. So I fixed it.

Running `npm run build` updated the `version.ts` file as well; I'm happy to amend this PR to remove that if you don't want that merged back.