### PR TITLE
Make solution URI-safe when sending to API

### DIFF
--- a/src/io/api.ts
+++ b/src/io/api.ts
@@ -139,7 +139,7 @@ const sendSolution = (
       ...USER_AGENT_HEADER,
     },
     method: "POST",
-    body: `level=${part}&answer=${solution}`,
+    body: `level=${part}&answer=${encodeURIComponent(solution)}`,
   })
     .then((res) => {
       if (res.status !== 200) {


### PR DESCRIPTION
My correct solution for 2022 day 25 was failing when submitting through aocrunner. I know it was correct because submitting it manually on the website worked.

I suspect that the problem is that the solution isn't being URI encoded, and since the solution contained equals (`=`) characters, the answer was not properly received at the API end.

This PR simply wraps the solution in `encodeURIComponent()` in the body of the `POST` fetch.

I haven't confirmed that this is the reason it was rejecting my correct answer, but the solution should be URI encoded regardless.