### PR TITLE
Multi Year Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ This repo contains the utility library to create and run [Advent of Code](https:
 
 - Creates JavaScript or TypeScript repository for AoC solutions with a simple CLI menu.
 - Runs your solutions in watch mode (with extremely fast compilation for TS using [esbuild](https://esbuild.github.io/)).
-- Allows you to fetch the input and send the solutions directly via terminal.
+- Allows you to fetch the sample input, problem input and send the solutions directly via terminal.
 - Prevents you from sending empty solutions and incorrect solutions twice (so you won't accidentally get the time penalty).
 - Provides a template for AoC solutions that you can customize.
 - Takes care of loading the input, measuring solution time, and running simple unit tests (supports async and sync code).
-- Automatically creates and updates README file.
+- Automatically creates and updates global, year, and day README files.
 
 ## Installation
 
@@ -32,18 +32,18 @@ It will guide you through the configuration with simple CLI menu.
 - initialize your version control system (ex: `git init`) _(optional)_
 - add your AoC session key `AOC_SESSION_KEY` to the `.env` file (you can find it in cookie file when you sign in at [adventofcode.com](https://adventofcode.com/)) _(optional)_
 - customize your template folder `src/template` _(optional)_
-- start solving the puzzles by running `start <day_number>` command with your package manager, for example:
+- start solving the puzzles by running `start <year_number> <day_number>` command with your package manager, for example:
 
 ```
-npm start 1
+npm start 2023 1
 
 // or
 
-yarn start 1
+yarn start 2023 1
 
 // or
 
-pnpm start 1
+pnpm start 2023 1
 ```
 
 ## Join my leaderboard
@@ -71,7 +71,7 @@ Starting from version 1.7.0 AoC Runner sets the correct request header as [reque
 
 This library creates modern, ESM compatible project - that means that you have to specify the extensions in your imports (that are not imported from `node_modules`).
 
-Always use `.js` extension for custom imports, even when importing `.ts` files (TypeScript ignores them, but the compiled code relies on them).
+**Always use `.js` extension for custom imports, even when importing `.ts` files (TypeScript ignores them, but the compiled code relies on them).**
 
 Examples:
 

--- a/src/actions/build.ts
+++ b/src/actions/build.ts
@@ -1,19 +1,28 @@
 import fs from "fs"
+import kleur from "kleur"
+import path from "path"
 import getAllFiles from "../utils/getAllFiles.js"
 import buildSource from "./processes/buildSource.js"
 import buildDefinitions from "./processes/buildDefinitions.js"
 
-const build = () => {
-  if (fs.existsSync("dist")) {
+const build = (yearRaw: string) => {
+  const year = yearRaw && (yearRaw.match(/\d{4}/) ?? [])[0]
+
+  if (year === undefined) {
+    console.log(kleur.red("No year specified."))
+    process.exit(1)
+  }
+
+  if (fs.existsSync(path.join(year, "dist"))) {
     console.log("Removing old build...")
-    fs.rmSync("dist", { recursive: true })
+    fs.rmSync(path.join(year, "dist"), { recursive: true })
     console.log("Building source files...")
   }
 
   const files = getAllFiles("src")
 
-  buildSource(files, false)
-  buildDefinitions()
+  buildSource(year, files, false)
+  buildDefinitions(year)
 }
 
 export default build

--- a/src/actions/dev.ts
+++ b/src/actions/dev.ts
@@ -123,7 +123,7 @@ const send = async (config: Config, dayNum: number, part: 1 | 2) => {
   if (status === Status["SOLVED"]) {
     config.days[dayNum - 1][part === 1 ? "part1" : "part2"].solved = true
     saveConfig(config)
-    updateReadme()
+    updateReadme(dayNum)
     return true
   }
 

--- a/src/actions/dev.ts
+++ b/src/actions/dev.ts
@@ -257,7 +257,7 @@ const dev = async (yearRaw: string | undefined, dayRaw: string | undefined) => {
   }
 
   chokidar
-    .watch(path.join("src", year), { ignoreInitial: true })
+    .watch([path.join("src", "utils"), path.join("src", year)], { ignoreInitial: true })
     .on("add", reload)
     .on("change", reload)
 

--- a/src/actions/dev.ts
+++ b/src/actions/dev.ts
@@ -160,10 +160,10 @@ const dev = async (yearRaw: string | undefined, dayRaw: string | undefined) => {
   if (configYear == undefined) {
 	const yearDir = path.join("src", year);
 	fs.mkdirSync(yearDir, { recursive: true })
-	save(yearDir, "README.md", readmeYearMD(config.language, config.years.find(y => y.year === Number(year))!))
     config.years.push(configYear = { year: yearNum, days: aocrunnerDaysJSON() });
 	config.years.sort((a, b) => a.year - b.year);
 	saveConfig(config);
+	save(yearDir, "README.md", readmeYearMD(config.language, config.years.find(y => y.year === Number(year))!))
   }
 
   if (yearNum < 2015 || yearNum > new Date().getFullYear()) {

--- a/src/actions/dev.ts
+++ b/src/actions/dev.ts
@@ -9,7 +9,7 @@ import runSolution from "./processes/runSolution.js"
 import getLatestVersion from "./processes/getLatestVersion.js"
 import copy from "../io/copy.js"
 import { readConfig, saveConfig } from "../io/config.js"
-import { getInput, sendSolution, Status } from "../io/api.js"
+import { getInput, getPuzzleTitle, sendSolution, Status } from "../io/api.js"
 
 import readmeDayMD from "../configs/readmeDayMD.js"
 import asciiPrompt, { AsciiOptions } from "../prompts/asciiPrompt.js"
@@ -17,6 +17,7 @@ import commandPrompt from "../prompts/commandPrompt.js"
 import type { Config } from "../types/common"
 import updateReadme from "./updateReadMe.js"
 import version from "../version.js"
+import { get } from "http"
 
 let latestVersion: string | null = null
 getLatestVersion().then((v) => {
@@ -137,7 +138,7 @@ const send = async (config: Config, dayNum: number, part: 1 | 2) => {
   return false
 }
 
-const dev = (dayRaw: string | undefined) => {
+const dev = async (dayRaw: string | undefined) => {
   const day = dayRaw && (dayRaw.match(/\d+/) ?? [])[0]
   const config = readConfig()
 
@@ -175,7 +176,12 @@ const dev = (dayRaw: string | undefined) => {
     fs.writeFileSync(inputPath, "")
 
     if (!fs.existsSync(dayReadmePath)) {
-      fs.writeFileSync(dayReadmePath, readmeDayMD(config.year, dayNum))
+	  const dayTitle = await getPuzzleTitle(config.year, dayNum, inputPath);
+	  if ( dayTitle != null ) {
+	    config.days[dayNum - 1].title = dayTitle;
+		saveConfig(config);
+	  }
+      fs.writeFileSync(dayReadmePath, readmeDayMD(config.year, dayNum, dayTitle))
     }
   }
 

--- a/src/actions/dev.ts
+++ b/src/actions/dev.ts
@@ -167,11 +167,11 @@ const dev = async (yearRaw: string | undefined, dayRaw: string | undefined) => {
   }
 
   if (yearNum < 2015 || yearNum > new Date().getFullYear()) {
-    console.log(kleur.red(`Wrong year - chose day between 2015 and ${new Date().getFullYear()}.`))
+    console.log(kleur.red(`Wrong year - choose year between 2015 and ${new Date().getFullYear()}.`))
     process.exit(1)
   }
   if (dayNum < 1 || dayNum > 25) {
-    console.log(kleur.red("Wrong day - chose day between 1 and 25."))
+    console.log(kleur.red("Wrong day - choose day between 1 and 25."))
     process.exit(1)
   }
 

--- a/src/actions/init.ts
+++ b/src/actions/init.ts
@@ -84,7 +84,7 @@ const init = async () => {
     execSync(formatCmd, { cwd: dir, stdio: "inherit" })
   }
 
-  const yearDir = path.join(dir, setup.year.toString())
+  const yearDir = path.join(srcDir, setup.year.toString())
 
   if (fs.existsSync(yearDir)) {
     console.log(`Year ${setup.year} Project already exists.`)

--- a/src/actions/processes/buildDefinitions.ts
+++ b/src/actions/processes/buildDefinitions.ts
@@ -1,10 +1,11 @@
 import { spawnSync } from "child_process"
+import path from "path"
 import kleur from "kleur"
 
-const buildDefinitions = () => {
+const buildDefinitions = (year: string) => {
   console.log("\nBuilding definition files...\n")
   const t0 = process.hrtime.bigint()
-  spawnSync("tsc", ["--emitDeclarationOnly", "--outDir", "dist"], {
+  spawnSync("tsc", ["--emitDeclarationOnly", "--outDir", path.join(year, "dist")], {
     stdio: "inherit",
     shell: true,
   })

--- a/src/actions/processes/buildSource.ts
+++ b/src/actions/processes/buildSource.ts
@@ -4,7 +4,7 @@ import path from "path"
 const buildSource = (year: string, input: string | string[], sourcemap: boolean = true) => {
   const files = Array.isArray(input) ? input : [input]
   const outDir = Array.isArray(input)
-    ? path.join(year, "dist")
+    ? path.join("dist", year)
     : path.parse(input).dir.replace(/^src/, "dist")
 
   console.log("Transpiling...\n")

--- a/src/actions/processes/buildSource.ts
+++ b/src/actions/processes/buildSource.ts
@@ -1,10 +1,10 @@
 import { spawnSync } from "child_process"
 import path from "path"
 
-const buildSource = (input: string | string[], sourcemap: boolean = true) => {
+const buildSource = (year: string, input: string | string[], sourcemap: boolean = true) => {
   const files = Array.isArray(input) ? input : [input]
   const outDir = Array.isArray(input)
-    ? "dist"
+    ? path.join(year, "dist")
     : path.parse(input).dir.replace(/^src/, "dist")
 
   console.log("Transpiling...\n")

--- a/src/actions/updateReadMe.ts
+++ b/src/actions/updateReadMe.ts
@@ -1,58 +1,173 @@
-import { saveReadme, readReadme, saveDayReadme, readDayReadme } from "../io/readme.js"
+import { saveReadme, readReadme, saveDayReadme, readDayReadme, readGlobalReadme, saveGlobalReadme } from "../io/readme.js"
 import toFixed from "../utils/toFixed.js"
 import { stripIndents } from "common-tags"
 import { renderDayBadges, renderResults } from "../configs/readmeMD.js"
 import { readConfig } from "../io/config.js"
 
-export const updateReadme = () => {
-  const config = readConfig()
-  const badges = renderDayBadges(config)
-  const results = renderResults(config)
+export const updateReadme = (currentDay?: number) => {
+	const config = readConfig()
 
-  const readme = readReadme()
-    .replace(
-      /<!--SOLUTIONS-->(.|\n|\r)+<!--\/SOLUTIONS-->/,
-      `<!--SOLUTIONS-->\n\n${badges}\n\n<!--/SOLUTIONS-->`,
-    )
-    .replace(
-      /<!--RESULTS-->(.|\n|\r)+<!--\/RESULTS-->/,
-      `<!--RESULTS-->\n\n${results}\n\n<!--/RESULTS-->`,
-    )
+	// Update global readme file
+	try {
+		const currentYear = config.year;
+		let globalReadme = readGlobalReadme();
 
-  saveReadme(readme)
-
-  config.days.filter(day => day.part1.solved || day.part2.solved)
-  .forEach((d, index) => {
-	  const day = String(index + 1).padStart(2, "0")
-	  const part1 = d.part1;
-	  const part2 = d.part2;
-
-	  let timeBoth = 0
-
-	  if (part1.solved) {
-		timeBoth += part1.time ?? 0
-	  }
-	  if (part2.solved) {
-		timeBoth += part2.time ?? 0
-	  }
-
-	  const dayResults = stripIndents`
-		\`\`\`
-		Time part 1: ${part1.time !== null && part1.solved ? toFixed(part1.time) + "ms" : "-"}
-		Time part 2: ${part2.time !== null && part2.solved ? toFixed(part2.time) + "ms" : "-"}
-		Both parts: ${timeBoth !== 0 ? toFixed(timeBoth) + "ms" : "-"}
-		\`\`\`
-		`;
-
-	  const dayReadme = readDayReadme(index + 1)
-		.replace(
-		  /## Results(.|\n|\r)+## Notes/,
-		  `## Results\n\n${dayResults}\n\n## Notes`,
-		)
+		let totalStars = 0;
+		let totalTime = 0;
+		let stars = config.days
+			.map(({ part1, part2 }, index) => {
+				if (part1.solved) {
+					totalStars++;
+					totalTime += part1.time ?? 0;
+				}
+				if (part2.solved) {
+					totalStars++;
+					totalTime += part2.time ?? 0;
+				}
+				const star =
+					part1.solved && part2.solved ? "★" :
+						part1.solved || part2.solved ? "☆" : "⭒";
 	
-	  console.log(`Updating day ${day} readme...`);
-	  saveDayReadme(index + 1, dayReadme)
-  });
+				return star;
+			}).join("");
+
+		let regex = /<!--SOLUTIONS-->(.|\n|\r)+<!--\/SOLUTIONS-->/;
+		let match = globalReadme.match(regex);
+
+		if (match != null) {
+			const lines = match[0].split("\n");
+	
+			let yearReplaceIndex = lines.findIndex(line => line.includes(`badge/${currentYear}`));
+	
+			if (yearReplaceIndex == -1) {
+				// Find position...
+				let yearInsertIndex = -1;
+				for (let index = 0; index < lines.length; index++) {
+					const [left, right] = lines[index].split("badge/");
+					if (right != undefined) {
+						if ( Number(right.substring(0, 4)) < currentYear ) {
+							yearInsertIndex = index;
+							break;
+						}
+					}
+				}
+
+				if (yearInsertIndex == -1) {
+					yearInsertIndex = lines.length - 2;
+				}
+
+				lines.splice(yearReplaceIndex = yearInsertIndex, 0, "");
+			}
+		
+			if (totalStars >= 49) {
+				stars = stars.replace("★", "✨")
+			}
+			const color = totalStars >= 40 ? "green" : totalStars >= 20 ? "yellow" : "gray";
+		
+			lines[yearReplaceIndex] = `[![Year](https://badgen.net/badge/${currentYear}/${stars}/${color}?icon=typescript&labelColor=blue&scale=1.3)](${currentYear})  `;
+		
+			globalReadme = globalReadme.replace(regex, lines.join("\n"));
+		}
+
+		regex = /<!--RESULTS-->(.|\n|\r)+<!--\/RESULTS-->/;
+		match = globalReadme.match(regex);
+
+		if (match != null) {
+			const lines = match[0].split("\n");
+
+			let yearReplaceIndex = lines.findIndex(line => line.includes(`Year ${currentYear}`)) - 1;
+	
+			if (yearReplaceIndex < 0) {
+				// Find position...
+				let yearInsertIndex = -1;
+				for (let index = 0; index < lines.length; index++) {
+					const [left, right] = lines[index].split("Year ");
+					if (right != undefined) {
+						if ( Number(right) < currentYear ) {
+							yearInsertIndex = index - 1;
+							break;
+						}
+					}
+				}
+
+				if (yearInsertIndex > -1) {
+					yearReplaceIndex = yearInsertIndex;
+				}
+				else {
+					yearReplaceIndex = lines.length - 1;
+				}
+				lines.splice(yearReplaceIndex, 0, ...["", "", "", "", "", ""]);
+			}			
+
+			const yearInfo = [
+				"```",
+				`Year ${currentYear}`,
+				`Total stars: ${totalStars}/50`,
+				`Total time: ${toFixed(totalTime)}ms`,
+				"```",
+				""
+			]
+
+			lines.splice(yearReplaceIndex, 6, ...yearInfo);
+			globalReadme = globalReadme.replace(regex, lines.join("\n"));
+		}
+
+		saveGlobalReadme(globalReadme);
+	} catch (error) {
+		if ( ( error as Error ).message.indexOf( "no such file or directory" ) == -1 ) {
+			console.error({ error });		
+		}
+	}
+
+	const badges = renderDayBadges(config)
+	const results = renderResults(config)
+
+	// Update year readme file
+	const readme = readReadme()
+		.replace(
+			/<!--SOLUTIONS-->(.|\n|\r)+<!--\/SOLUTIONS-->/,
+			`<!--SOLUTIONS-->\n\n${badges}\n\n<!--/SOLUTIONS-->`,
+		)
+		.replace(
+			/<!--RESULTS-->(.|\n|\r)+<!--\/RESULTS-->/,
+			`<!--RESULTS-->\n\n${results}\n\n<!--/RESULTS-->`,
+		)
+
+	saveReadme(readme)
+
+	// Update day readme files
+	config.days.filter((d, index) => (currentDay == undefined || (currentDay - 1 == index)) && (d.part1.solved || d.part2.solved))
+		.forEach((d, index) => {
+			const day = String(index + 1).padStart(2, "0")
+			const part1 = d.part1;
+			const part2 = d.part2;
+
+			let timeBoth = 0
+
+			if (part1.solved) {
+				timeBoth += part1.time ?? 0
+			}
+			if (part2.solved) {
+				timeBoth += part2.time ?? 0
+			}
+
+			const dayResults = stripIndents`
+			\`\`\`
+			Time part 1: ${part1.time !== null && part1.solved ? toFixed(part1.time) + "ms" : "-"}
+			Time part 2: ${part2.time !== null && part2.solved ? toFixed(part2.time) + "ms" : "-"}
+			Both parts: ${timeBoth !== 0 ? toFixed(timeBoth) + "ms" : "-"}
+			\`\`\`
+			`;
+
+			const dayReadme = readDayReadme(index + 1)
+				.replace(
+					/## Results(.|\n|\r)+## Notes/,
+					`## Results\n\n${dayResults}\n\n## Notes`
+				);
+			
+			console.log(`Updating day ${day} readme...`);
+			saveDayReadme(index + 1, dayReadme)
+		});
 }
 
 export default updateReadme

--- a/src/actions/updateReadMe.ts
+++ b/src/actions/updateReadMe.ts
@@ -3,10 +3,33 @@ import toFixed from "../utils/toFixed.js"
 import { stripIndents } from "common-tags"
 import { renderDayBadges, renderResults } from "../configs/readmeMD.js"
 import { readConfig } from "../io/config.js"
+import type { Config } from "../types/common"
 
 export const updateReadme = (currentDay?: number) => {
 	const config = readConfig()
 
+	updateGlobalReadme(config);
+
+	const badges = renderDayBadges(config)
+	const results = renderResults(config)
+
+	// Update year readme file
+	const readme = readReadme()
+		.replace(
+			/<!--SOLUTIONS-->(.|\n|\r)+<!--\/SOLUTIONS-->/,
+			`<!--SOLUTIONS-->\n\n${badges}\n\n<!--/SOLUTIONS-->`,
+		)
+		.replace(
+			/<!--RESULTS-->(.|\n|\r)+<!--\/RESULTS-->/,
+			`<!--RESULTS-->\n\n${results}\n\n<!--/RESULTS-->`,
+		)
+
+	saveReadme(readme)
+
+	updateDayReadme(config, currentDay);
+}
+
+const updateGlobalReadme = (config: Config) => {
 	// Update global readme file
 	try {
 		const currentYear = config.year;
@@ -118,23 +141,9 @@ export const updateReadme = (currentDay?: number) => {
 			console.error({ error });		
 		}
 	}
+}
 
-	const badges = renderDayBadges(config)
-	const results = renderResults(config)
-
-	// Update year readme file
-	const readme = readReadme()
-		.replace(
-			/<!--SOLUTIONS-->(.|\n|\r)+<!--\/SOLUTIONS-->/,
-			`<!--SOLUTIONS-->\n\n${badges}\n\n<!--/SOLUTIONS-->`,
-		)
-		.replace(
-			/<!--RESULTS-->(.|\n|\r)+<!--\/RESULTS-->/,
-			`<!--RESULTS-->\n\n${results}\n\n<!--/RESULTS-->`,
-		)
-
-	saveReadme(readme)
-
+const updateDayReadme = (config: Config, currentDay?: number) => {
 	// Update day readme files
 	config.days
 		.forEach((d, index) => {

--- a/src/actions/updateReadMe.ts
+++ b/src/actions/updateReadMe.ts
@@ -1,4 +1,6 @@
-import { saveReadme, readReadme } from "../io/readme.js"
+import { saveReadme, readReadme, saveDayReadme, readDayReadme } from "../io/readme.js"
+import toFixed from "../utils/toFixed.js"
+import { stripIndents } from "common-tags"
 import { renderDayBadges, renderResults } from "../configs/readmeMD.js"
 import { readConfig } from "../io/config.js"
 
@@ -18,6 +20,39 @@ export const updateReadme = () => {
     )
 
   saveReadme(readme)
+
+  config.days.filter(day => day.part1.solved || day.part2.solved)
+  .forEach((d, index) => {
+	  const day = String(index + 1).padStart(2, "0")
+	  const part1 = d.part1;
+	  const part2 = d.part2;
+
+	  let timeBoth = 0
+
+	  if (part1.solved) {
+		timeBoth += part1.time ?? 0
+	  }
+	  if (part2.solved) {
+		timeBoth += part2.time ?? 0
+	  }
+
+	  const dayResults = stripIndents`
+		\`\`\`
+		Time part 1: ${part1.time !== null && part1.solved ? toFixed(part1.time) + "ms" : "-"}
+		Time part 2: ${part2.time !== null && part2.solved ? toFixed(part2.time) + "ms" : "-"}
+		Both parts: ${timeBoth !== 0 ? toFixed(timeBoth) + "ms" : "-"}
+		\`\`\`
+		`;
+
+	  const dayReadme = readDayReadme(index + 1)
+		.replace(
+		  /## Results(.|\n|\r)+## Notes/,
+		  `## Results\n\n${dayResults}\n\n## Notes`,
+		)
+	
+	  console.log(`Updating day ${day} readme...`);
+	  saveDayReadme(index + 1, dayReadme)
+  });
 }
 
 export default updateReadme

--- a/src/actions/updateReadMe.ts
+++ b/src/actions/updateReadMe.ts
@@ -136,37 +136,37 @@ export const updateReadme = (currentDay?: number) => {
 	saveReadme(readme)
 
 	// Update day readme files
-	config.days.filter((d, index) => (currentDay == undefined || (currentDay - 1 == index)) && (d.part1.solved || d.part2.solved))
+	config.days
 		.forEach((d, index) => {
-			const day = String(index + 1).padStart(2, "0")
-			const part1 = d.part1;
-			const part2 = d.part2;
+			if ((currentDay == undefined || (currentDay - 1 == index)) && (d.part1.solved || d.part2.solved)) {
+				const part1 = d.part1;
+				const part2 = d.part2;
 
-			let timeBoth = 0
+				let timeBoth = 0
 
-			if (part1.solved) {
-				timeBoth += part1.time ?? 0
+				if (part1.solved) {
+					timeBoth += part1.time ?? 0
+				}
+				if (part2.solved) {
+					timeBoth += part2.time ?? 0
+				}
+
+				const dayResults = stripIndents`
+				\`\`\`
+				Time part 1: ${part1.time !== null && part1.solved ? toFixed(part1.time) + "ms" : "-"}
+				Time part 2: ${part2.time !== null && part2.solved ? toFixed(part2.time) + "ms" : "-"}
+				Both parts: ${timeBoth !== 0 ? toFixed(timeBoth) + "ms" : "-"}
+				\`\`\`
+				`;
+
+				const dayReadme = readDayReadme(index + 1)
+					.replace(
+						/## Results(.|\n|\r)+## Notes/,
+						`## Results\n\n${dayResults}\n\n## Notes`
+					);
+				
+				saveDayReadme(index + 1, dayReadme)
 			}
-			if (part2.solved) {
-				timeBoth += part2.time ?? 0
-			}
-
-			const dayResults = stripIndents`
-			\`\`\`
-			Time part 1: ${part1.time !== null && part1.solved ? toFixed(part1.time) + "ms" : "-"}
-			Time part 2: ${part2.time !== null && part2.solved ? toFixed(part2.time) + "ms" : "-"}
-			Both parts: ${timeBoth !== 0 ? toFixed(timeBoth) + "ms" : "-"}
-			\`\`\`
-			`;
-
-			const dayReadme = readDayReadme(index + 1)
-				.replace(
-					/## Results(.|\n|\r)+## Notes/,
-					`## Results\n\n${dayResults}\n\n## Notes`
-				);
-			
-			console.log(`Updating day ${day} readme...`);
-			saveDayReadme(index + 1, dayReadme)
 		});
 }
 

--- a/src/actions/updateReadMe.ts
+++ b/src/actions/updateReadMe.ts
@@ -1,20 +1,42 @@
-import { saveReadme, readReadme, saveDayReadme, readDayReadme, readGlobalReadme, saveGlobalReadme } from "../io/readme.js"
+import { saveYearReadme, readYearReadme, saveDayReadme, readDayReadme, readGlobalReadme, saveGlobalReadme } from "../io/readme.js"
 import toFixed from "../utils/toFixed.js"
 import { stripIndents } from "common-tags"
-import { renderDayBadges, renderResults } from "../configs/readmeMD.js"
+import { renderGlobalYearInfo } from "../configs/readmeMD.js"
+import { renderYearDayBadges, renderYearResults } from "../configs/readmeYearMD.js"
 import { readConfig } from "../io/config.js"
-import type { Config } from "../types/common"
+import type { YearConfig } from "../types/common"
 
-export const updateReadme = (currentDay?: number) => {
-	const config = readConfig()
+export const updateReadmes = (currentYear: string, currentDay?: number) => {
+	const config = readConfig();
+	const yearConfig = config.years.find(y => y.year == Number(currentYear))!;
+	updateGlobalReadme(yearConfig);
+	updateYearReadme(yearConfig);
+	updateDayReadme(yearConfig, currentDay);
+}
 
-	updateGlobalReadme(config);
-
-	const badges = renderDayBadges(config)
-	const results = renderResults(config)
+const updateGlobalReadme = (config: YearConfig) => {
+	const globalInfo = renderGlobalYearInfo(config)
 
 	// Update year readme file
-	const readme = readReadme()
+	const readme = readGlobalReadme()
+		.replace(
+			/<!--SOLUTIONS-->(.|\n|\r)+<!--\/SOLUTIONS-->/,
+			`<!--SOLUTIONS-->\n\n${globalInfo?.badges ?? ""}\n\n<!--/SOLUTIONS-->`,
+		)
+		.replace(
+			/<!--RESULTS-->(.|\n|\r)+<!--\/RESULTS-->/,
+			`<!--RESULTS-->\n\n${globalInfo?.results ?? ""}\n\n<!--/RESULTS-->`,
+		)
+
+	saveGlobalReadme(readme);
+}
+
+const updateYearReadme = (config: YearConfig) => {
+	const badges = renderYearDayBadges(config)
+	const results = renderYearResults(config)
+
+	// Update year readme file
+	const readme = readYearReadme(config.year)
 		.replace(
 			/<!--SOLUTIONS-->(.|\n|\r)+<!--\/SOLUTIONS-->/,
 			`<!--SOLUTIONS-->\n\n${badges}\n\n<!--/SOLUTIONS-->`,
@@ -24,126 +46,10 @@ export const updateReadme = (currentDay?: number) => {
 			`<!--RESULTS-->\n\n${results}\n\n<!--/RESULTS-->`,
 		)
 
-	saveReadme(readme)
-
-	updateDayReadme(config, currentDay);
+	saveYearReadme(config.year, readme);
 }
 
-const updateGlobalReadme = (config: Config) => {
-	// Update global readme file
-	try {
-		const currentYear = config.year;
-		let globalReadme = readGlobalReadme();
-
-		let totalStars = 0;
-		let totalTime = 0;
-		let stars = config.days
-			.map(({ part1, part2 }, index) => {
-				if (part1.solved) {
-					totalStars++;
-					totalTime += part1.time ?? 0;
-				}
-				if (part2.solved) {
-					totalStars++;
-					totalTime += part2.time ?? 0;
-				}
-				const star =
-					part1.solved && part2.solved ? "★" :
-						part1.solved || part2.solved ? "☆" : "⭒";
-	
-				return star;
-			}).join("");
-
-		let regex = /<!--SOLUTIONS-->(.|\n|\r)+<!--\/SOLUTIONS-->/;
-		let match = globalReadme.match(regex);
-
-		if (match != null) {
-			const lines = match[0].split("\n");
-	
-			let yearReplaceIndex = lines.findIndex(line => line.includes(`badge/${currentYear}`));
-	
-			if (yearReplaceIndex == -1) {
-				// Find position...
-				let yearInsertIndex = -1;
-				for (let index = 0; index < lines.length; index++) {
-					const [left, right] = lines[index].split("badge/");
-					if (right != undefined) {
-						if ( Number(right.substring(0, 4)) < currentYear ) {
-							yearInsertIndex = index;
-							break;
-						}
-					}
-				}
-
-				if (yearInsertIndex == -1) {
-					yearInsertIndex = lines.length - 2;
-				}
-
-				lines.splice(yearReplaceIndex = yearInsertIndex, 0, "");
-			}
-		
-			if (totalStars >= 49) {
-				stars = stars.replace("★", "✨")
-			}
-			const color = totalStars >= 40 ? "green" : totalStars >= 20 ? "yellow" : "gray";
-		
-			lines[yearReplaceIndex] = `[![Year](https://badgen.net/badge/${currentYear}/${stars}/${color}?icon=typescript&labelColor=blue&scale=1.3)](${currentYear})  `;
-		
-			globalReadme = globalReadme.replace(regex, lines.join("\n"));
-		}
-
-		regex = /<!--RESULTS-->(.|\n|\r)+<!--\/RESULTS-->/;
-		match = globalReadme.match(regex);
-
-		if (match != null) {
-			const lines = match[0].split("\n");
-
-			let yearReplaceIndex = lines.findIndex(line => line.includes(`Year ${currentYear}`)) - 1;
-	
-			if (yearReplaceIndex < 0) {
-				// Find position...
-				let yearInsertIndex = -1;
-				for (let index = 0; index < lines.length; index++) {
-					const [left, right] = lines[index].split("Year ");
-					if (right != undefined) {
-						if ( Number(right) < currentYear ) {
-							yearInsertIndex = index - 1;
-							break;
-						}
-					}
-				}
-
-				if (yearInsertIndex > -1) {
-					yearReplaceIndex = yearInsertIndex;
-				}
-				else {
-					yearReplaceIndex = lines.length - 1;
-				}
-				lines.splice(yearReplaceIndex, 0, ...["", "", "", "", "", ""]);
-			}			
-
-			const yearInfo = [
-				"```",
-				`Year ${currentYear}`,
-				`Total stars: ${totalStars}/50`,
-				`Total time: ${toFixed(totalTime)}ms`,
-				"```",
-				""
-			]
-
-			lines.splice(yearReplaceIndex, 6, ...yearInfo);
-			globalReadme = globalReadme.replace(regex, lines.join("\n"));
-		}
-
-		saveGlobalReadme(globalReadme);
-	} catch (error) {
-		if ( ( error as Error ).message.indexOf( "no such file or directory" ) == -1 ) {
-			console.error({ error });		
-		}
-	}
-}
-
-const updateDayReadme = (config: Config, currentDay?: number) => {
+const updateDayReadme = (config: YearConfig, currentDay?: number) => {
 	// Update day readme files
 	config.days
 		.forEach((d, index) => {
@@ -168,15 +74,15 @@ const updateDayReadme = (config: Config, currentDay?: number) => {
 				\`\`\`
 				`;
 
-				const dayReadme = readDayReadme(index + 1)
+				const dayReadme = readDayReadme(config.year, index + 1)
 					.replace(
 						/## Results(.|\n|\r)+## Notes/,
 						`## Results\n\n${dayResults}\n\n## Notes`
 					);
 				
-				saveDayReadme(index + 1, dayReadme)
+				saveDayReadme(config.year, index + 1, dayReadme)
 			}
 		});
 }
 
-export default updateReadme
+export default updateReadmes

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,8 @@
 import init from "./actions/init.js"
 import dev from "./actions/dev.js"
 import build from "./actions/build.js"
-import updateReadme from "./actions/updateReadMe.js"
+import kleur from "kleur"
+import updateReadmes from "./actions/updateReadMe.js"
 import dotenv from "dotenv"
 import version from "./version.js"
 
@@ -29,15 +30,19 @@ switch (String(command || "").toLowerCase()) {
     break
   }
   case "day": {
-    dev(args[0])
+	if ( args.length < 2 ) {
+		console.log(kleur.red("No must specify both a year and a day to start."))
+		break;
+	}
+    dev(args[0], args[1])
     break
   }
   case "build": {
-    build()
+    build(args[0])
     break
   }
   case "update:readme": {
-    updateReadme()
+    updateReadmes(args[0])
     break;
   }
   default: {

--- a/src/configs/packageJSON.ts
+++ b/src/configs/packageJSON.ts
@@ -3,7 +3,8 @@ import version from "../version.js"
 
 const packageJSON = ({ year, language, author }: Setup) => {
   const build = language === "ts" ? { build: "aocrunner build" } : {}
-
+  const esbuild = language === "ts" ? { esbuild: "^0.19.8" } : {}
+  
   return {
     name: `aoc${year}`,
     version: "1.0.0",
@@ -21,6 +22,7 @@ const packageJSON = ({ year, language, author }: Setup) => {
     devDependencies: {
       "@types/node": "^16.11.6",
       aocrunner: `^${version}`,
+	  ...esbuild,
       prettier: "^2.8.0",
     },
     dependencies: {},

--- a/src/configs/readmeDayMD.ts
+++ b/src/configs/readmeDayMD.ts
@@ -1,9 +1,9 @@
 import type { Setup, Config } from "../types/common"
 import { stripIndents } from "common-tags"
 
-const readmeDayMD = (year: number, day: number) => {
+const readmeDayMD = (year: number, day: number, title: string | null) => {
   return stripIndents`
-    # 🎄 Advent of Code ${year} - day ${day} 🎄
+    # 🎄 Advent of Code ${year} - Day ${day} ${title != null ? "- " + title : ""} 🎄
 
     ## Info
 

--- a/src/configs/readmeDayMD.ts
+++ b/src/configs/readmeDayMD.ts
@@ -1,4 +1,3 @@
-import type { Setup, Config } from "../types/common"
 import { stripIndents } from "common-tags"
 
 const readmeDayMD = (year: number, day: number, title: string | null) => {

--- a/src/configs/readmeDayMD.ts
+++ b/src/configs/readmeDayMD.ts
@@ -9,6 +9,14 @@ const readmeDayMD = (year: number, day: number) => {
 
     Task description: [link](https://adventofcode.com/${year}/day/${day})
 
+	## Results
+
+	\`\`\`
+	Time part 1: -
+	Time part 2: -
+	Both parts: -
+	\`\`\`
+		
     ## Notes
 
     ...

--- a/src/configs/readmeMD.ts
+++ b/src/configs/readmeMD.ts
@@ -30,7 +30,7 @@ const renderResults = (config: Config) => {
   let totalStars = 0
 
   const results = config.days
-    .map(({ part1, part2 }, index) => {
+    .map(({ title, part1, part2 }, index) => {
       const day = String(index + 1).padStart(2, "0")
 
       let timeBoth = 0
@@ -52,7 +52,7 @@ const renderResults = (config: Config) => {
 
       return stripIndents`
       \`\`\`
-      Day ${day}
+      Day ${day}${title != null ? " - " + title : ""}
       Time part 1: ${
         part1.time !== null && part1.solved ? toFixed(part1.time) + "ms" : "-"
       }

--- a/src/configs/readmeMD.ts
+++ b/src/configs/readmeMD.ts
@@ -71,8 +71,18 @@ const renderGlobalYearInfo = (config: YearConfig) => {
 		match = globalReadme.match(regex);
 
 		if (match != null) {
-			const lines = match[1].split("\n").filter(line => line.trim() != "");
-
+			let lines = match[1].split("\n");
+			const firstContentIndex = lines.findIndex(line => line.trim() !== "");
+			let lastContentIndex = -1;
+			for (let index = lines.length - 1; index >= 0; index--) {
+				const line = lines[index];
+				if (line.trim() !== "") {
+					lastContentIndex = index;
+					break;
+				}
+			}
+			lines = lines.slice(firstContentIndex, lastContentIndex + 1);
+	
 			let yearReplaceIndex = lines.findIndex(line => line.includes(`Year ${currentYear}`)) - 1;
 	
 			if (yearReplaceIndex < 0) {
@@ -98,15 +108,19 @@ const renderGlobalYearInfo = (config: YearConfig) => {
 			}			
 
 			const yearInfo = [
-				"",
 				"```",
 				`Year ${currentYear}`,
 				`Total stars: ${totalStars}/50`,
 				`Total time: ${toFixed(totalTime)}ms`,
-				"```"
+				"```",
+				""
 			]
 
 			lines.splice(yearReplaceIndex, 6, ...yearInfo);
+
+			if (lines[lines.length - 1] == "") {
+				lines.pop();
+			}
 			results = lines.join("\n");
 		}
 

--- a/src/configs/readmeYearMD.ts
+++ b/src/configs/readmeYearMD.ts
@@ -1,0 +1,124 @@
+import type { YearConfig } from "../types/common"
+import { stripIndents } from "common-tags"
+import toFixed from "../utils/toFixed.js"
+
+const renderYearDayBadges = (config: YearConfig) => {
+  return config.days
+    .map(({ part1, part2 }, index) => {
+      const day = String(index + 1).padStart(2, "0")
+
+      const color =
+        (part1.solved && part2.solved) || (part1.solved && day === "25")
+          ? "green"
+          : part1.solved || part2.solved
+          ? "yellow"
+          : "gray"
+
+      const badge = `![Day](https://badgen.net/badge/${day}/%E2%98%8${
+        part1.solved ? 5 : 6
+      }%E2%98%8${
+        part2.solved || (part1.solved && day === "25") ? 5 : 6
+      }/${color})`
+
+      return color !== "gray" ? `[${badge}](day${day})` : badge
+    })
+    .join("\n")
+}
+
+const renderYearResults = (config: YearConfig) => {
+  let totalTime = 0
+  let totalStars = 0
+
+  const results = config.days
+    .map(({ title, part1, part2 }, index) => {
+      const day = String(index + 1).padStart(2, "0")
+
+      let timeBoth = 0
+
+      if (part1.solved) {
+        totalStars++
+        totalTime += part1.time ?? 0
+        timeBoth += part1.time ?? 0
+      }
+      if (part2.solved) {
+        totalStars++
+        totalTime += part2.time ?? 0
+        timeBoth += part2.time ?? 0
+      }
+
+      if (day === "25" && part1.solved) {
+        totalStars++
+      }
+
+      return stripIndents`
+      \`\`\`
+      Day ${day}${title != null ? " - " + title : ""}
+      Time part 1: ${
+        part1.time !== null && part1.solved ? toFixed(part1.time) + "ms" : "-"
+      }
+      Time part 2: ${
+        part2.time !== null && part2.solved ? toFixed(part2.time) + "ms" : "-"
+      }
+      Both parts: ${timeBoth !== 0 ? toFixed(timeBoth) + "ms" : "-"}
+      \`\`\`
+    `
+    })
+    .join("\n\n")
+
+  const summary = stripIndents`
+    \`\`\`
+    Total stars: ${totalStars}/50
+    Total time: ${toFixed(totalTime)}ms
+    \`\`\`
+  `
+
+  return [results, summary].join("\n\n")
+}
+
+const readmeYearMD = (
+  language: string,
+  config: YearConfig,
+) => {
+  const lang = language === "ts" ? "TypeScript" : "JavaScript"
+
+  const dayBadges = renderYearDayBadges(config)
+  const results = renderYearResults(config)
+
+  return stripIndents`
+    <!-- Entries between SOLUTIONS and RESULTS tags are auto-generated -->
+
+    [![AoC](https://badgen.net/badge/AoC/${config.year}/blue)](https://adventofcode.com/${config.year})
+    [![Node](https://badgen.net/badge/Node/v16.13.0+/blue)](https://nodejs.org/en/download/)
+    ![Language](https://badgen.net/badge/Language/${lang}/blue)
+    [![Template](https://badgen.net/badge/Template/aocrunner/blue)](https://github.com/caderek/aocrunner)
+
+    # 🎄 Advent of Code ${config.year} 🎄
+
+    ## Solutions
+
+    <!--SOLUTIONS-->
+
+    ${dayBadges}
+
+    <!--/SOLUTIONS-->
+
+    _Click a badge to go to the specific day._
+
+    ---
+
+    ## Results
+
+    <!--RESULTS-->
+
+    ${results}
+
+    <!--/RESULTS-->
+
+    ---
+
+    ✨🎄🎁🎄🎅🎄🎁🎄✨
+  `
+}
+
+export { renderYearDayBadges, renderYearResults }
+export default readmeYearMD

--- a/src/configs/runnerJSON.ts
+++ b/src/configs/runnerJSON.ts
@@ -6,6 +6,7 @@ const aocrunnerJSON = ({ year, language }: Setup): Config => {
     year,
     language,
     days: new Array(25).fill(0).map((_, i) => ({
+      title: null,	
       part1: {
         solved: false,
         result: null,

--- a/src/configs/runnerJSON.ts
+++ b/src/configs/runnerJSON.ts
@@ -1,26 +1,34 @@
-import type { Setup, Config } from "../types/common"
+import type { Setup, Config, DayConfig } from "../types/common"
 
-const aocrunnerJSON = ({ year, language }: Setup): Config => {
+const aocrunnerDaysJSON = (): DayConfig[] => new Array(25).fill(0).map((_, i) => ({
+	title: null,
+	part1: {
+		solved: false,
+		result: null,
+		attempts: [],
+		time: null,
+	},
+	part2: {
+		solved: false,
+		result: null,
+		attempts: [],
+		time: null,
+	},
+}));
+
+const aocrunnerJSON = ({ year, packageManager, language }: Setup): Config => {
   return {
     version: 1,
-    year,
     language,
-    days: new Array(25).fill(0).map((_, i) => ({
-      title: null,	
-      part1: {
-        solved: false,
-        result: null,
-        attempts: [],
-        time: null,
-      },
-      part2: {
-        solved: false,
-        result: null,
-        attempts: [],
-        time: null,
-      },
-    })),
+	packageManager,
+	years: [
+		{
+			year,
+			days: aocrunnerDaysJSON()
+		}
+	]
   }
 }
 
+export { aocrunnerDaysJSON }
 export default aocrunnerJSON

--- a/src/configs/tsconfigJSON.ts
+++ b/src/configs/tsconfigJSON.ts
@@ -13,10 +13,10 @@ const tsconfigJSON = ({ strict }: Setup) => {
       allowSyntheticDefaultImports: true,
       moduleResolution: "node",
       forceConsistentCasingInFileNames: true,
-      importHelpers: true,
+      importHelpers: true
     },
     include: ["src"],
-    exclude: ["node_modules", "src/**/*.test.ts", "src/**/*.temp.ts"],
+    exclude: ["node_modules", "src/template", "src/**/*.test.ts", "src/**/*.temp.ts"]
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ const runSolution = async (solution: Solution, input: string, part: 1 | 2) => {
 const runAsync = async (
   solutions: Solutions,
   inputFile: string,
+  year: number,
   day: number,
 ) => {
   const config = readConfig()
@@ -125,23 +126,24 @@ const runAsync = async (
   }
 
   console.log(`\nTotal time: ${toFixed(totalTime)}ms`)
-
-  config.days[day - 1].part1.result =
+  const configYear = config.years.find(y => y.year === year)!;
+  configYear.days[day - 1].part1.result =
     output1?.result === undefined ? null : String(output1.result)
 
-  config.days[day - 1].part1.time =
+  configYear.days[day - 1].part1.time =
     output1?.result === undefined ? null : output1.time
 
-  config.days[day - 1].part2.result =
+  configYear.days[day - 1].part2.result =
     output2?.result === undefined ? null : String(output2.result)
 
-  config.days[day - 1].part2.time =
+  configYear.days[day - 1].part2.time =
     output2?.result === undefined ? null : output2.time
 
   saveConfig(config)
 }
 
 const run = (solutions: Solutions, customInputFile?: string) => {
+  let year = null
   let day = null
   let inputFile = null
 
@@ -149,9 +151,11 @@ const run = (solutions: Solutions, customInputFile?: string) => {
     const dayName = (customInputFile.match(/day\d\d/) || [])[0]
     inputFile = customInputFile
     day = dayName ? Number(dayName.slice(-2)) : null
+	// Don't have year parsed here, need to figure out how this funciton is used
   } else {
     const dayData = getDayData()
-    day = dayData.day
+    year = dayData.year
+	day = dayData.day
     inputFile = dayData.inputFile
   }
 
@@ -167,13 +171,25 @@ const run = (solutions: Solutions, customInputFile?: string) => {
     return
   }
 
+  if (year === null) {
+    console.log(
+      kleur.red(stripIndent`
+        Couldn't detect the year number!
+
+        Make sure that your directory contains the year number
+        in format "XXXX" from 2015 to the current year.
+      `),
+    )
+    return
+  }
+
   if (day === null) {
     console.log(
       kleur.red(stripIndent`
         Couldn't detect the day number!
 
         Make sure that your directory or file name contains the day number
-        inf format "dayXX", where each X means number from 0 to 9.
+        in format "dayXX", where each X means number from 0 to 9.
       `),
     )
     return
@@ -191,7 +207,7 @@ const run = (solutions: Solutions, customInputFile?: string) => {
     return
   }
 
-  runAsync(solutions, inputFile, day)
+  runAsync(solutions, inputFile, year, day)
 }
 
 export default run

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ type Tests = {
   expected: string | number | bigint | void
 }[]
 
-type Solution = (input: string) => string | number | bigint | void
+type Solution = (input: string, testName?: string) => string | number | bigint | void
 
 type Solutions = {
   part1?: {
@@ -37,9 +37,8 @@ const runTests = async (
 
     const data = trimTestInputs ? stripIndent(input) : input
 
-    const result = await solution(data)
-
     const testName = `Part ${part}, test ${i + 1}${name ? `, ${name}` : ""}`
+    const result = await solution(data, testName)
 
     if (result === expected) {
       console.log(kleur.green(`${testName} - passed`))

--- a/src/io/api.ts
+++ b/src/io/api.ts
@@ -82,7 +82,7 @@ const handleErrors = (e: Error) => {
   return Status["ERROR"]
 }
 
-const getPuzzleTitle = async (year: number, day: number, path: string) => {
+const getPuzzleInfo = async (year: number, day: number, path: string) => {
   const API_URL = process.env.AOC_API ?? "https://adventofcode.com"
 
   try {
@@ -97,15 +97,20 @@ const getPuzzleTitle = async (year: number, day: number, path: string) => {
 		throw new Error(String(res.status))
 	}
 	
-	const body = await res.text();
+	let body = await res.text();
     // Extract the content of the h2 element using a regular expression
-    const h2ContentRegex = /<h2>--- Day \d+: (.*?) ---<\/h2>/;
-    const matches = body.match(h2ContentRegex);
-    return matches ? matches[1] : null;
+    let matches = body.match(/<h2>--- Day \d+: (.*?) ---<\/h2>/);
+	const title = matches ? matches[1] : null;
+	if ( body.indexOf("For example:") > -1 ) {
+		body = body.split("For example:")[1];
+	}
+    matches = body.match(/<pre><code>(.*?)<\/code><\/pre>/s);
+	const testData = matches ? matches[1].trim() : null;
+	return [title, testData];
   } catch (error) {
-	handleErrors(error as Error);
+	  handleErrors(error as Error);
+	  return [null, null];
   }
-  return null;
 }
 
 const getInput = async (year: number, day: number, path: string) => {
@@ -248,4 +253,4 @@ const sendSolution = (
     .catch(handleErrors)
 }
 
-export { getInput, getPuzzleTitle, sendSolution, Status }
+export { getInput, getPuzzleInfo, sendSolution, Status }

--- a/src/io/api.ts
+++ b/src/io/api.ts
@@ -82,6 +82,32 @@ const handleErrors = (e: Error) => {
   return Status["ERROR"]
 }
 
+const getPuzzleTitle = async (year: number, day: number, path: string) => {
+  const API_URL = process.env.AOC_API ?? "https://adventofcode.com"
+
+  try {
+	const res = await fetch(`${API_URL}/${year}/day/${day}`, {
+		headers: {
+		cookie: `session=${process.env.AOC_SESSION_KEY}`,
+		...USER_AGENT_HEADER,
+		},
+	});
+
+	if (res.status !== 200) {
+		throw new Error(String(res.status))
+	}
+	
+	const body = await res.text();
+    // Extract the content of the h2 element using a regular expression
+    const h2ContentRegex = /<h2>--- Day \d+: (.*?) ---<\/h2>/;
+    const matches = body.match(h2ContentRegex);
+    return matches ? matches[1] : null;
+  } catch (error) {
+	handleErrors(error as Error);
+  }
+  return null;
+}
+
 const getInput = async (year: number, day: number, path: string) => {
   const API_URL = process.env.AOC_API ?? "https://adventofcode.com"
 
@@ -222,4 +248,4 @@ const sendSolution = (
     .catch(handleErrors)
 }
 
-export { getInput, sendSolution, Status }
+export { getInput, getPuzzleTitle, sendSolution, Status }

--- a/src/io/config.ts
+++ b/src/io/config.ts
@@ -1,13 +1,14 @@
 import fs from "fs"
+import path from "path"
 import type { Config } from "../types/common"
 
 const readConfig = (): Config => {
-  return JSON.parse(fs.readFileSync(".aocrunner.json").toString())
+  return JSON.parse(fs.readFileSync(path.join("src", ".aocrunner.json")).toString())
 }
 
 const saveConfig = (config: Config) => {
-  const data = JSON.stringify(config, null, 2)
-  fs.writeFileSync(".aocrunner.json", data)
+  const data = JSON.stringify(config, null, 2);
+  fs.writeFileSync(path.join("src", ".aocrunner.json"), data)
 }
 
 export { saveConfig, readConfig }

--- a/src/io/readme.ts
+++ b/src/io/readme.ts
@@ -8,4 +8,11 @@ const saveReadme = (readme: string) => {
   fs.writeFileSync("README.md", readme)
 }
 
-export { saveReadme, readReadme }
+const readDayReadme = (day: number): string => {
+	return fs.readFileSync(`src/day${day.toString().padStart(2, '0')}/README.md`).toString()
+}
+const saveDayReadme = (day: number, readme: string) => {
+	fs.writeFileSync(`src/day${day.toString().padStart(2, '0')}/README.md`, readme)
+}
+  
+export { saveReadme, readReadme, saveDayReadme, readDayReadme }

--- a/src/io/readme.ts
+++ b/src/io/readme.ts
@@ -1,26 +1,26 @@
 import fs from "fs"
 
-const readReadme = (): string => {
-  return fs.readFileSync("README.md").toString()
-}
-
-const saveReadme = (readme: string) => {
-  fs.writeFileSync("README.md", readme)
-}
-
-const readDayReadme = (day: number): string => {
-	return fs.readFileSync(`src/day${day.toString().padStart(2, '0')}/README.md`).toString()
-}
-const saveDayReadme = (day: number, readme: string) => {
-	fs.writeFileSync(`src/day${day.toString().padStart(2, '0')}/README.md`, readme)
-}
-
 const readGlobalReadme = (): string => {
-	return fs.readFileSync("../README.md").toString()
+	return fs.readFileSync("README.md").toString()
 }
   
 const saveGlobalReadme = (readme: string) => {
-	fs.writeFileSync("../README.md", readme)
+	fs.writeFileSync("README.md", readme)
+}
+
+const readYearReadme = (year: number): string => {
+  return fs.readFileSync(`src/${year.toString()}/README.md`).toString()
+}
+
+const saveYearReadme = (year: number, readme: string) => {
+  fs.writeFileSync(`src/${year.toString()}/README.md`, readme)
+}
+
+const readDayReadme = (year: number, day: number): string => {
+	return fs.readFileSync(`src/${year.toString()}/day${day.toString().padStart(2, '0')}/README.md`).toString()
+}
+const saveDayReadme = (year:number, day: number, readme: string) => {
+	fs.writeFileSync(`src/${year.toString()}/day${day.toString().padStart(2, '0')}/README.md`, readme)
 }
   
-export { saveReadme, readReadme, saveDayReadme, readDayReadme, readGlobalReadme, saveGlobalReadme }
+export { saveGlobalReadme, readGlobalReadme, saveYearReadme, readYearReadme, saveDayReadme, readDayReadme }

--- a/src/io/readme.ts
+++ b/src/io/readme.ts
@@ -14,5 +14,13 @@ const readDayReadme = (day: number): string => {
 const saveDayReadme = (day: number, readme: string) => {
 	fs.writeFileSync(`src/day${day.toString().padStart(2, '0')}/README.md`, readme)
 }
+
+const readGlobalReadme = (): string => {
+	return fs.readFileSync("../README.md").toString()
+}
   
-export { saveReadme, readReadme, saveDayReadme, readDayReadme }
+const saveGlobalReadme = (readme: string) => {
+	fs.writeFileSync("../README.md", readme)
+}
+  
+export { saveReadme, readReadme, saveDayReadme, readDayReadme, readGlobalReadme, saveGlobalReadme }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -19,5 +19,9 @@ export type Config = {
   version: number
   year: number
   language: "js" | "ts"
-  days: { part1: DayConfig; part2: DayConfig }[]
+  days: { 
+    title: null | string;
+    part1: DayConfig; 
+    part2: DayConfig 
+  }[]
 }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,27 +1,35 @@
 export type Setup = {
-  year: number
-  name: string
-  language: "ts" | "js"
-  packageManager: "npm" | "yarn" | "pnpm"
-  author: string
-  semicolons: boolean
-  strict: boolean
+	name: string
+    year: number
+    language: "ts" | "js"
+	packageManager: "npm" | "yarn" | "pnpm"
+	author: string
+	semicolons: boolean
+	strict: boolean
 }
 
-type DayConfig = {
+type PartConfig = {
   solved: boolean
   result: any
   attempts: any[]
   time: null | number
 }
+  
+  
+export type DayConfig = {
+  title: null | string;
+  part1: PartConfig; 
+  part2: PartConfig 
+}
+
+export type YearConfig = {
+  year: number
+  days: DayConfig[]
+}
 
 export type Config = {
+  packageManager: "npm" | "yarn" | "pnpm"
+  language: "ts" | "js"
   version: number
-  year: number
-  language: "js" | "ts"
-  days: { 
-    title: null | string;
-    part1: DayConfig; 
-    part2: DayConfig 
-  }[]
+  years: YearConfig[]
 }

--- a/src/utils/getDayData.ts
+++ b/src/utils/getDayData.ts
@@ -21,6 +21,7 @@ const getDayData = () => {
 
   if (!dayDir) {
     return {
+      year: null,
       day: null,
       inputFile: null,
     }
@@ -33,7 +34,8 @@ const getDayData = () => {
   }
 
   return {
-    day: Number(dayDir[dayDir.length - 1].slice(-2)),
+    year: Number(dayDir[dayDir.length - 2]),
+	day: Number(dayDir[dayDir.length - 1].slice(-2)),
     inputFile: [...dayDir, "input.txt"].join(path.sep),
   }
 }

--- a/templates/ts/template/index.ts
+++ b/templates/ts/template/index.ts
@@ -4,17 +4,14 @@ const parseInput = (rawInput: string) => rawInput
 
 const part1 = (rawInput: string) => {
   const input = parseInput(rawInput)
-
-  return
 }
 
 const part2 = (rawInput: string) => {
   const input = parseInput(rawInput)
-
-  return
 }
 
 run({
+  onlyTests: false,
   part1: {
     tests: [
       // {
@@ -25,14 +22,7 @@ run({
     solution: part1,
   },
   part2: {
-    tests: [
-      // {
-      //   input: ``,
-      //   expected: "",
-      // },
-    ],
-    solution: part2,
+    solution: part2
   },
-  trimTestInputs: true,
-  onlyTests: false,
+  trimTestInputs: true
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "ESNext",
     "module": "es2020",
     "removeComments": true,
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "es2020",
     "removeComments": true,
     "declaration": true,
-    "outDir": "node_modules/aocrunner/lib",
+    "outDir": "./lib",
     "preserveConstEnums": true,
     "strict": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Various improvements and multi year support.  See [my repo](https://github.com/terryaney/advent-of-code) for idea of what it now looks like.

1. Instead of replicating `aocrunner` every year, each year is nested under `src\NNNN` where `NNNN` is the year.
	1. `npm start` now requires a year and day parameter, e.g. `npm start 2019 1`
	1. `update:readme` now requires a year parameter, e.g. `npm run update:readme 2019`
	1. `build` now requires a year parameter, e.g. `npm run build 2019`

1. Readme improvements
	1. There is a global readme summarizing 'year' results.
	1. Each year has a readme summarizing 'day' results (mostly same as before with some typo fixes/formatting).
	1. Each day has a readme summarizing solutions in the `Results` section.
	1. The year and day readmes also pull the puzzle/day titles.
	1. Same as the previous year readme, the global and day readmes automatically update when submitting solutions (or when `update:readme` is ran).

1. Puzzle automation improvements
	1. Puzzle title is pulled and stored in readme files and `.aocrunner.json` file.
	1. The sample input is attempted to be pulled and if successful and a `{testData}` placeholder is found in the template `index.ts` file, it will be replaced with the sample input.

1. Core Updates
	1. Obviously had to pass 'year' around to several of the core functions.
	1. Refactored `Config` object definition to support multiple years.
	1. Added `src/template` to `tsconfig.json` `exclude` list.
	1. Changed the `tsconfig.json` `outdir` to `./lib` to match the build script (in attempt to support VS Code debugging).