### PR TITLE
fix: replace npx esbuild with direct API to fix pnpm warnings

### DIFF
--- a/src/actions/build.ts
+++ b/src/actions/build.ts
@@ -3,7 +3,7 @@ import getAllFiles from "../utils/getAllFiles.js"
 import buildSource from "./processes/buildSource.js"
 import buildDefinitions from "./processes/buildDefinitions.js"
 
-const build = () => {
+const build = async () => {
   if (fs.existsSync("dist")) {
     console.log("Removing old build...")
     fs.rmSync("dist", { recursive: true })
@@ -12,7 +12,7 @@ const build = () => {
 
   const files = getAllFiles("src")
 
-  buildSource(files, false)
+  await buildSource(files, false)
   buildDefinitions()
 }
 

--- a/src/actions/dev.ts
+++ b/src/actions/dev.ts
@@ -137,7 +137,7 @@ const send = async (config: Config, dayNum: number, part: 1 | 2) => {
   return false
 }
 
-const dev = (dayRaw: string | undefined) => {
+const dev = async (dayRaw: string | undefined) => {
   const day = dayRaw && (dayRaw.match(/\d+/) ?? [])[0]
   const config = readConfig()
 
@@ -184,12 +184,12 @@ const dev = (dayRaw: string | undefined) => {
   const files = getAllFiles("src")
 
   if (config.language === "ts") {
-    buildSource(files)
+    await buildSource(files)
   }
 
   runSolution(dayNum, indexFile)
 
-  const reload = (file: string) => {
+  const reload = async (file: string) => {
     if (![".js", ".ts", ".mjs"].includes(path.parse(file).ext)) {
       return
     }
@@ -197,7 +197,7 @@ const dev = (dayRaw: string | undefined) => {
     console.clear()
 
     if (config.language === "ts") {
-      buildSource(file)
+      await buildSource(file)
     }
 
     runSolution(dayNum, indexFile)

--- a/src/actions/processes/buildSource.ts
+++ b/src/actions/processes/buildSource.ts
@@ -1,7 +1,10 @@
-import { spawnSync } from "child_process"
+import * as esbuild from "esbuild"
 import path from "path"
 
-const buildSource = (input: string | string[], sourcemap: boolean = true) => {
+const buildSource = async (
+  input: string | string[],
+  sourcemap: boolean = true,
+) => {
   const files = Array.isArray(input) ? input : [input]
   const outDir = Array.isArray(input)
     ? "dist"
@@ -9,19 +12,19 @@ const buildSource = (input: string | string[], sourcemap: boolean = true) => {
 
   console.log("Transpiling...\n")
 
-  spawnSync(
-    "npx",
-    [
-      "esbuild",
-      ...files,
-      "--format=esm",
-      `--outdir=${outDir}`,
-      "--platform=node",
-      "--target=node16",
-      ...(sourcemap ? ["--sourcemap"] : []),
-    ],
-    { stdio: "inherit", shell: true },
-  )
+  try {
+    await esbuild.build({
+      entryPoints: files,
+      format: "esm",
+      outdir: outDir,
+      platform: "node",
+      target: "node16",
+      sourcemap: sourcemap,
+    })
+  } catch (error) {
+    console.error("Build failed:", error)
+    process.exit(1)
+  }
 }
 
 export default buildSource

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,11 +29,11 @@ switch (String(command || "").toLowerCase()) {
     break
   }
   case "day": {
-    dev(args[0])
+    await dev(args[0])
     break
   }
   case "build": {
-    build()
+    await build()
     break
   }
   case "update:readme": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
-    "module": "es2020",
+    "target": "es2022",
+    "module": "es2022",
     "removeComments": true,
     "declaration": true,
     "outDir": "node_modules/aocrunner/lib",


### PR DESCRIPTION
Using npx to run esbuild was causing npm warnings running aocrunner with pnpm. This happened because pnpm exports its config as npm_config_* environment variables, which npm doesn't recognize.

Switched to importing and calling the esbuild API directly instead of spawning a subprocess. This makes the build process work cleanly with any package manager and removes the subprocess overhead.

Made buildSource, build, and dev functions async to support the new esbuild API calls. Updated tsconfig to es2022 to enable top-level await in the CLI.